### PR TITLE
Fix syntax error with run_context fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.0
+
+- check Chef for run_context compatibility (#52)
+- Disable Slack handler in why-run mode (#49)
+- Fix a few of the additional lint complaints (#47)
+
 ## 0.8.1
 
 - Pins chef_handler version (#46)

--- a/files/default/slack_handler_util.rb
+++ b/files/default/slack_handler_util.rb
@@ -50,7 +50,10 @@ class SlackHandlerUtil
   def run_status_cookbook_detail(context = {})
     case context['cookbook_detail_level'] || @default_config[:cookbook_detail_level]
     when "all"
-      cookbooks = run_context.cookbook_collection
+      if Chef.respond_to?(:run_context)
+        cookbooks = Chef.run_context.cookbook_collection
+      else
+        cookbooks = run_context.cookbook_collection
       " using cookbooks #{cookbooks.values.map { |x| x.name.to_s + ' ' + x.version }}"
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license          'Apache-2.0'
 description      'Installs/Configures a Chef handler for reporting results to a Slack channel.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.8.1'
+version          '0.9.0'
 
 depends 'chef_handler', '~> 2.1.2'
 


### PR DESCRIPTION
Missed an 'end' in run_context_fix branch - previous CI did not find any issues since I did not bump the cookbook version when testing!